### PR TITLE
Disable `AndroidGradlePluginVersion` lint check

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
-        disable += listOf("GradleDependency", "MissingApplicationIcon")
+        disable += listOf("AndroidGradlePluginVersion", "GradleDependency", "MissingApplicationIcon")
     }
     buildFeatures.compose = true
     composeOptions.kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()


### PR DESCRIPTION
Failing a build due to an outdated Android gradle plugin (AGP) is excessive/unnecessary.