### PR TITLE
Wrap `datadogClientTokens` in `doLast` closure

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -127,25 +127,27 @@ tasks.register("datadogClientTokens") {
     description = "Writes Datadog client tokens to Kotlin source code for use in the project"
     group = "Build"
 
-    val properties = Properties().apply {
-        load(file("$projectDir/local.properties").inputStream())
-    }
+    doFirst {
+        val properties = Properties().apply {
+            load(file("$projectDir/local.properties").inputStream())
+        }
 
-    listOf("android", "ios", "js",).forEach { target ->
-        val property = "datadog.clientToken.$target"
-        val token = properties.getOrElse(property) { error("Missing $property in $projectDir/local.properties") }
-        val path = file("$buildDir/generated/sources/datadog/${target}Main/kotlin")
-        val sourceFile = file("$path/DatadogClientToken.kt")
-        path.createDirectory()
-        sourceFile.createNewFile()
-        sourceFile.writeText(
-            """
-            package com.juul.datadog.sample
-            
-            internal actual val DATADOG_CLIENT_TOKEN: String = "$token"
-            
-            """.trimIndent()
-        )
+        listOf("android", "ios", "js",).forEach { target ->
+            val property = "datadog.clientToken.$target"
+            val token = properties.getOrElse(property) { error("Missing $property in $projectDir/local.properties") }
+            val path = file("$buildDir/generated/sources/datadog/${target}Main/kotlin")
+            val sourceFile = file("$path/DatadogClientToken.kt")
+            path.createDirectory()
+            sourceFile.createNewFile()
+            sourceFile.writeText(
+                """
+                package com.juul.datadog.sample
+                
+                internal actual val DATADOG_CLIENT_TOKEN: String = "$token"
+                
+                """.trimIndent()
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Trying to view Gradle `tasks` would fail (being unable to locate `library/local.properties`, if absent).
This PR makes the execution of `datadogClientTokens` lazy, allowing `tasks` to be queried even without that file. The `datadogClientTokens` task will now fail when **run**, and **not** fail when **configured**.