### PR TITLE
Remove deprecated `kotlin.js.compiler` option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 group=com.juul.datadog.sample
 org.gradle.jvmargs=-Xmx1g
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.js.compiler=ir
 android.useAndroidX=true


### PR DESCRIPTION
```
w: ⚠️ Deprecated Gradle Property 'kotlin.js.compiler' Used
The `kotlin.js.compiler` deprecated property is used in your build.
```