### PR TITLE
Use `maxim-lobanov/setup-xcode` to configure Xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'


### PR DESCRIPTION
At time of this PR creation, the `macos-latest` GitHub runners [had the following Xcode versions installed](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode):

| Version        | Build    | Path                           | Symlinks                                                  |
| -------------- | -------- | ------------------------------ | --------------------------------------------------------- |
| 16.2           | 16C5032a | /Applications/Xcode_16.2.app   | /Applications/Xcode_16.2.0.app                            |
| 16.1           | 16B40    | /Applications/Xcode_16.1.app   | /Applications/Xcode_16.1.0.app                            |
| 15.4 (default) | 15F31d   | /Applications/Xcode_15.4.app   | /Applications/Xcode_15.4.0.app<br>/Applications/Xcode.app |
| 15.3           | 15E204a  | /Applications/Xcode_15.3.app   | /Applications/Xcode_15.3.0.app                            |
| 15.2           | 15C500b  | /Applications/Xcode_15.2.app   | /Applications/Xcode_15.2.0.app                            |
| 15.1           | 15C65    | /Applications/Xcode_15.1.app   | /Applications/Xcode_15.1.0.app                            |
| 15.0.1         | 15A507   | /Applications/Xcode_15.0.1.app | /Applications/Xcode_15.0.app                              |

Note that Xcode 15.4 is the **default**.

As recommended by https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140, we should be selecting the appropriate Xcode version to use; in this case, I've configured us to use the `latest-stable` — which at this time should be Xcode 16.2.

This resolves the CI issue(s) we're hitting currently open PRs:

> ```
> The project ‘<name>’ cannot be opened because it is in a future Xcode project file format (77).
> ```