### PR TITLE
Update Android compile and target versions to `37`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.2"
 android-compile = "37"
 android-min = "21"
-android-target = "36"
+android-target = "37"
 androidx-compose = "1.9.4"
 datadog-kmp = "0.6.0"
 jvm-toolchain = "11"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-android-compile = "36"
+android-compile = "37"
 android-min = "21"
 android-target = "36"
 androidx-compose = "1.9.4"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version-catalog compile SDK bump with no application logic changes; typical follow-up is verifying the project still builds with API 37.
> 
> **Overview**
> Bumps the **`android-compile`** version catalog entry from **36** to **37**, so Android modules compile against API 37. **`android-target`** remains **36**; only the compile SDK is raised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7825027a7f8d365d49fb1a146f7a6fcfff73742e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->